### PR TITLE
Render double and triple bonds and support additional file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@ CGBuilder — Visual tool to build CG molecule models
 
 This project is a fork of [Original CGBuilder](https://github.com/jbarnoud/cgbuilder), with additional
 functionality for complex bead placement, and Shaker format export.
+
+Double-bond rendering notes
+---------------------------
+
+- For consistent display of double and triple bonds prefer input formats that include bond-order metadata such as SDF (.sdf, .sd) or MOL2 (.mol2). PDB and GRO files often lack bond-order information and may not show multiple bonds correctly.

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         </ul>
     
     <div class="info-footnote">
-        Tip: You can increase and decrease a beads "weight" to position it in the right spot!
+        Tip: You can increase and decrease a bead's "weight" to position it in the right spot!
     </div>
 
     <div class="info-footnote">

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 </div>
     <form>
         <label for="files" class="btn">Load molecule</label>
-        <input id="mol-select" type="file" name="files" accept=".pdb,.cif,.ent,.gz,.gro"/>
+        <input id="mol-select" type="file" name="files" accept=".pdb,.cif,.ent,.gz,.gro,.sdf,.sd,.mol2,.mol"/>
     </form>
     <button class="new-bead" disabled>New bead</button>
     <button class="toggle-aa-labels" disabled>Hide labels</button>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -221,12 +221,12 @@ class Visualization {
     attachRepresentation(component) {
         this.representation = component.addRepresentation(
 	        "ball+stick",
-	        {
+            bondAwareRepresentationParams({
 	            sele: "not all",
 	            radiusScale: 1.6,
 	            color: "#f4b642",
 	            opacity: 0.6
-	        },
+            }),
 	    );
     }
 
@@ -731,6 +731,18 @@ function copyTextToClipboard(text) {
     return Promise.resolve();
 }
 
+// Helper to ensure that double and triple bonds are properly rendered
+function bondAwareRepresentationParams(overrides = {}) {
+    return Object.assign(
+        {
+            multipleBond: true,
+            bondSpacing: 1,
+            bondScale: 0.4,
+        },
+        overrides
+    );
+}
+
 function loadMolecule(event, stage) {
     // Clear the stage if needed
     stage.removeAllComponents();
@@ -742,7 +754,7 @@ function loadMolecule(event, stage) {
     // Load the molecule
     let input = event.target.files[0]
 	stage.loadFile(input).then(function (component) {
-	    component.addRepresentation("ball+stick");
+        component.addRepresentation("ball+stick", bondAwareRepresentationParams());
 	    component.autoView();
 	    vizu.attachAALabels(component);
 	    vizu.attachRepresentation(component);


### PR DESCRIPTION
Enhance the visualization by rendering double and triple bonds. Allow input of sd, sdf, mol, and mol2 file formats. 